### PR TITLE
only use python shebang for executable files

### DIFF
--- a/ropperapp/__init__.py
+++ b/ropperapp/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/common/__init__.py
+++ b/ropperapp/common/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/common/abstract.py
+++ b/ropperapp/common/abstract.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/common/coloredstring.py
+++ b/ropperapp/common/coloredstring.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/common/enum.py
+++ b/ropperapp/common/enum.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/common/error.py
+++ b/ropperapp/common/error.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/common/utils.py
+++ b/ropperapp/common/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/console.py
+++ b/ropperapp/console.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/__init__.py
+++ b/ropperapp/disasm/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/arch.py
+++ b/ropperapp/disasm/arch.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/chain/__init__.py
+++ b/ropperapp/disasm/chain/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/chain/arch/__init__.py
+++ b/ropperapp/disasm/chain/arch/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/chain/arch/ropchainx86.py
+++ b/ropperapp/disasm/chain/arch/ropchainx86.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/chain/ropchain.py
+++ b/ropperapp/disasm/chain/ropchain.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/gadget.py
+++ b/ropperapp/disasm/gadget.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/disasm/rop.py
+++ b/ropperapp/disasm/rop.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/__init__.py
+++ b/ropperapp/loaders/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/elf.py
+++ b/ropperapp/loaders/elf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/elf_intern/__init__.py
+++ b/ropperapp/loaders/elf_intern/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/elf_intern/elf32_LSB.py
+++ b/ropperapp/loaders/elf_intern/elf32_LSB.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/elf_intern/elf32_MSB.py
+++ b/ropperapp/loaders/elf_intern/elf32_MSB.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/elf_intern/elf64_LSB.py
+++ b/ropperapp/loaders/elf_intern/elf64_LSB.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/elf_intern/elf64_MSB.py
+++ b/ropperapp/loaders/elf_intern/elf64_MSB.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/elf_intern/elf_gen.py
+++ b/ropperapp/loaders/elf_intern/elf_gen.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/loader.py
+++ b/ropperapp/loaders/loader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/mach_intern/__init__.py
+++ b/ropperapp/loaders/mach_intern/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/mach_intern/mach32.py
+++ b/ropperapp/loaders/mach_intern/mach32.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/mach_intern/mach64.py
+++ b/ropperapp/loaders/mach_intern/mach64.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/mach_intern/mach_gen.py
+++ b/ropperapp/loaders/mach_intern/mach_gen.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/mach_o.py
+++ b/ropperapp/loaders/mach_o.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/pe.py
+++ b/ropperapp/loaders/pe.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/pe_intern/__init__.py
+++ b/ropperapp/loaders/pe_intern/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/pe_intern/pe32.py
+++ b/ropperapp/loaders/pe_intern/pe32.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/pe_intern/pe64.py
+++ b/ropperapp/loaders/pe_intern/pe64.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/pe_intern/pe_gen.py
+++ b/ropperapp/loaders/pe_intern/pe_gen.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/loaders/raw.py
+++ b/ropperapp/loaders/raw.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/options.py
+++ b/ropperapp/options.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/printer/__init__.py
+++ b/ropperapp/printer/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/printer/elfprinter.py
+++ b/ropperapp/printer/elfprinter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/printer/machprinter.py
+++ b/ropperapp/printer/machprinter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/printer/peprinter.py
+++ b/ropperapp/printer/peprinter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/printer/printer.py
+++ b/ropperapp/printer/printer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/printer/rawprinter.py
+++ b/ropperapp/printer/rawprinter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/search/__init__.py
+++ b/ropperapp/search/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/ropperapp/search/search.py
+++ b/ropperapp/search/search.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # coding=utf-8
 #
 # Copyright 2014 Sascha Schirra

--- a/script/ropper
+++ b/script/ropper
@@ -1,3 +1,3 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # coding=utf-8
 __import__('ropperapp').start(__import__('sys').argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from setuptools import setup, find_packages
 import ropperapp
 


### PR DESCRIPTION
This removes the python2 shebang from simple module files.
Also the script/ropper file is changed from python2 to python to
have unified generic python call without version specific dependency.