### PR TITLE
Bugfix: crash when building mprotect ropchainx86

### DIFF
--- a/ropper/ropchain/arch/ropchainx86.py
+++ b/ropper/ropchain/arch/ropchainx86.py
@@ -734,7 +734,7 @@ class RopChainX86Mprotect(RopChainX86):
             self._printer.printInfo('jmp esp found')
             chain_tmp += jmp_esp
         else:
-            self-_printer.printInfo('no jmp esp found')
+            self._printer.printInfo('no jmp esp found')
             chain_tmp += '\n# ADD HERE JMP ESP\n\n'
 
         chain += self._printRebase()


### PR DESCRIPTION
Crash was caused by a minor typo, encountered when a jmp esp gadget isn't found