### PR TITLE
Add notion of "affected registers" to gadgets

### DIFF
--- a/ropper/gadget.py
+++ b/ropper/gadget.py
@@ -211,23 +211,8 @@ class Gadget(object):
         if not self.__affected_regs:
             self.__affected_regs = set()
 
-            if hex(self.address) == '0x478ec6L':
-                debug = True
-            else:
-                debug = False
-            debug=False
-
             full_line = self.simpleInstructionString()
             line = self.__lines[0][1]
-
-            if debug:
-                print('******** find affected regs *********')
-                print(self.simpleInstructionString())
-                print(full_line)
-
-            if debug:
-                from pprint import pprint
-                pprint(self.__arch._categories)
 
             for l_tup in self.__lines:
                 line = l_tup[1]
@@ -239,45 +224,8 @@ class Gadget(object):
 
                             if  match_all:
                                 if 'dst' in match_all.groupdict():
-                                    if debug:
-                                        print('-------- match --------')
-                                        print(cat)
-
-                                        print(self.simpleString())
-                                        print(match_all.groupdict())
                                     affected = match_all.groupdict()['dst']
                                     self.__affected_regs.add(affected)
-    #                                if debug:
-    #                                    try:
-    #                                        input("Press enter to continue")
-    #                                    except SyntaxError:
-    #                                        pass
-
-                                    '''
-                                    for g, i in r.groupindex.items():
-                                        if debug:
-                                            print('g: %s' % g)
-                                            print('i: %d' % i)
-                                            print('match all: %s' % match_all)
-                                            print(r.groupindex)
-
-                                        if type(match_all[0]) == tuple:
-                                            for e in set(match_all[0]):
-                                                self.__affected_regs.add(e)
-                                        else:
-                                            for e in set(match_all):
-                                    '''
-
-            if debug:
-                print(self.simpleString())
-                print('affected regs:')
-                print(self.__affected_regs)
-                print('********** affected regs end *************')
-#                try:
-#                    input("Press enter to continue")
-#                except SyntaxError:
-#                        pass
-
             return self.__affected_regs
         else:
             return self.__affected_regs
@@ -298,13 +246,6 @@ class Gadget(object):
 
                         self.__category = (cat, len(self.__lines) -1 ,match.groupdict())
                         self.__category[2]['affected'] = self.affected_regs
-                        '''
-                        print('category: %s' % str(self.__category))
-                        try:
-                            input("Press enter to continue")
-                        except SyntaxError:
-                            pass
-                        '''
                         return self.__category
             self.__category = (Category.NONE,)
 

--- a/ropper/gadget.py
+++ b/ropper/gadget.py
@@ -215,11 +215,10 @@ class Gadget(object):
                 debug = True
             else:
                 debug = False
-            debug=True
+            debug=False
 
             full_line = self.simpleInstructionString()
             line = self.__lines[0][1]
-            print(line)
 
             if debug:
                 print('******** find affected regs *********')
@@ -244,8 +243,8 @@ class Gadget(object):
                                         print('-------- match --------')
                                         print(cat)
 
-                                    print(self.simpleString())
-                                    print(match_all.groupdict())
+                                        print(self.simpleString())
+                                        print(match_all.groupdict())
                                     affected = match_all.groupdict()['dst']
                                     self.__affected_regs.add(affected)
     #                                if debug:

--- a/ropper/gadget.py
+++ b/ropper/gadget.py
@@ -208,7 +208,6 @@ class Gadget(object):
 
     @property
     def affected_regs(self):
-        print('getting affected regs')
         if not self.__affected_regs:
             self.__affected_regs = set()
 
@@ -216,6 +215,7 @@ class Gadget(object):
                 debug = True
             else:
                 debug = False
+            debug=True
 
             full_line = self.simpleInstructionString()
             line = self.__lines[0][1]
@@ -226,8 +226,9 @@ class Gadget(object):
                 print(self.simpleInstructionString())
                 print(full_line)
 
-            from pprint import pprint
-            pprint(self.__arch._categories)
+            if debug:
+                from pprint import pprint
+                pprint(self.__arch._categories)
 
             for l_tup in self.__lines:
                 line = l_tup[1]
@@ -235,41 +236,50 @@ class Gadget(object):
                     for regex in regexs[0]:
                         if regex != 'ret.+':
                             r = re.compile(regex)
-                            #match_all = r.findall(full_line)
-                            match_all = r.findall(line)
+                            match_all = r.match(line)
 
-                            if match_all:
+                            if  match_all:
+                                if 'dst' in match_all.groupdict():
+                                    if debug:
+                                        print('-------- match --------')
+                                        print(cat)
 
-                                if debug:
-                                    print('-------- match --------')
-                                    print(cat)
-#                                    try:
-#                                        input("Press enter to continue")
-#                                    except SyntaxError:
-#                                        pass
+                                    print(self.simpleString())
+                                    print(match_all.groupdict())
+                                    affected = match_all.groupdict()['dst']
+                                    self.__affected_regs.add(affected)
+    #                                if debug:
+    #                                    try:
+    #                                        input("Press enter to continue")
+    #                                    except SyntaxError:
+    #                                        pass
 
-                                for g, i in r.groupindex.items():
-                                    print('g: %s' % g)
-                                    print('i: %d' % i)
-                                    print('match all: %s' % match_all)
-                                    print(r.groupindex)
+                                    '''
+                                    for g, i in r.groupindex.items():
+                                        if debug:
+                                            print('g: %s' % g)
+                                            print('i: %d' % i)
+                                            print('match all: %s' % match_all)
+                                            print(r.groupindex)
 
-                                    if type(match_all[0]) == tuple:
-                                        for e in set(match_all[0]):
-                                            self.__affected_regs.add(e)
-                                    else:
-                                        for e in set(match_all):
-                                            self.__affected_regs.add(e)
+                                        if type(match_all[0]) == tuple:
+                                            for e in set(match_all[0]):
+                                                self.__affected_regs.add(e)
+                                        else:
+                                            for e in set(match_all):
+                                    '''
 
             if debug:
                 print(self.simpleString())
                 print('affected regs:')
                 print(self.__affected_regs)
                 print('********** affected regs end *************')
-                try:
-                    input("Press enter to continue")
-                except SyntaxError:
-                        pass
+#                try:
+#                    input("Press enter to continue")
+#                except SyntaxError:
+#                        pass
+
+            return self.__affected_regs
         else:
             return self.__affected_regs
 
@@ -288,8 +298,14 @@ class Gadget(object):
                                     return self.__category
 
                         self.__category = (cat, len(self.__lines) -1 ,match.groupdict())
+                        self.__category[2]['affected'] = self.affected_regs
+                        '''
                         print('category: %s' % str(self.__category))
-                        a = self.affected_regs
+                        try:
+                            input("Press enter to continue")
+                        except SyntaxError:
+                            pass
+                        '''
                         return self.__category
             self.__category = (Category.NONE,)
 

--- a/ropper/gadget.py
+++ b/ropper/gadget.py
@@ -208,21 +208,85 @@ class Gadget(object):
     @property
     def category(self):
         if not self.__category:
+            if hex(self.address) == '0x478ec6L':
+                debug = True
+            else:
+                debug = False
             line = self.__lines[0][1]
+            full_line = self.simpleInstructionString()
+            d = {}
             for cat, regexs in self.__arch._categories.items():
                 for regex in regexs[0]:
-                    match = re.match(regex, line)
+                    r = re.compile(regex)
+                    #match = re.match(regex, line)
+                    if cat == Category.STACK_PIVOT:
+                        match = r.findall(line)
+                    else:
+                        match = r.findall(full_line)
                     if match:
+                        if debug:
+                            print('******** category init *********')
+                            print(self.simpleInstructionString())
+                            if cat == Category.STACK_PIVOT:
+                                print(line)
+                            else:
+                                print(full_line)
+                            print('-------- match --------')
+                            print(cat)
+                            print(regex)
+                            print(match)
+                            try:
+                                input("Press enter to continue")
+                            except SyntaxError:
+                                    pass
+                        if debug:
+                            print('checking invalid')
+                            print(regexs[1])
                         for invalid in regexs[1]:
+                            if debug:
+                                print(invalid)
+                                print(self.__lines[1:])
                             for l in self.__lines[1:]:
                                 if l[1].startswith(invalid):
                                     self.__category = (Category.NONE,)
+                                    if debug:
+                                        print('invalid -> NONE')
+                                        print('********** init end *************')
                                     return self.__category
-                        d = match.groupdict()
-                        for key, value in d.items():
-                            d[key] = str(value)
 
-                        self.__category = (cat, len(self.__lines) -1 ,match.groupdict())
+                        print('dict:')
+                        print(d)
+                        print(r.groupindex.items())
+                        for g, i in r.groupindex.items():
+                            print('g: %s' % g)
+                            print('i: %d' % i)
+                            print('match: %s' % match)
+                            if g not in d:
+                                d[g] = []
+                            if type(match[0]) == tuple: 
+                                for m in match[0]:
+                                    d[g].append(str(m[i-1]))
+                            else:
+                                for m in match:
+                                    d[g].append(str(m))
+                            print(d)
+
+                        #d = match.groupdict()
+                        if debug:
+                            print('dict:')
+                            print(d)
+#                        for key, value in d.items():
+#                            d[key] = str(value)
+
+                        #self.__category = (cat, len(self.__lines) -1 ,match.groupdict())
+                        self.__category = (cat, len(self.__lines) -1 ,d)
+                        if debug:
+                            print(self.__category)
+                            print('********** init end *************')
+                            try:
+                                input("Press enter to continue")
+                            except SyntaxError:
+                                    pass
                         return self.__category
             self.__category = (Category.NONE,)
 

--- a/ropper/ropchain/arch/ropchainx86.py
+++ b/ropper/ropchain/arch/ropchainx86.py
@@ -210,9 +210,11 @@ class RopChainX86(RopChain):
             for binary in self._binaries:
                 for gadget in self._gadgets[binary]:
                     if gadget.category[0] == category and gadget.category[1] == quali:
-                        if badSrc and gadget.category[2]['src'] in badSrc:
+                        if badSrc and (gadget.category[2]['src'] in badSrc \
+                                       or gadget.affected_regs.intersection(badSrc)):
                             continue
-                        if badDst and gadget.category[2]['dst'] in badDst:
+                        if badDst and (gadget.category[2]['dst'] in badDst \
+                                       or gadget.affected_regs.intersection(badDst)):
                             continue
                         if not gadget.lines[len(gadget.lines)-1][1].strip().endswith('ret') or 'esp' in gadget.simpleString():
                             continue

--- a/ropper/ropchain/arch/ropchainx86.py
+++ b/ropper/ropchain/arch/ropchainx86.py
@@ -169,7 +169,7 @@ class RopChainX86(RopChain):
     def _printRopInstruction(self, gadget, padding=True, number=None):
         toReturn = ('rop += rebase_%d(%s) # %s\n' % (self._usedBinaries.index((gadget.fileName, gadget.section)),toHex(gadget.lines[0][0],4), gadget.simpleString()))
         if number is not None:
-            toReturn +=self._printPaddingInstruction(number)        
+            toReturn +=self._printPaddingInstruction(number)
         if padding:
             regs = self._paddingNeededFor(gadget)
             for i in range(len(regs)):
@@ -636,36 +636,38 @@ class RopChainX86System(RopChainX86):
         if address is None:
             section = self._binaries[0].getSection('.data')
             length = math.ceil(float(len(cmd))/4) * 4
-            
+            nulladdress = section.offset+0x1000
+
             try:
-                chain_tmp += self._createCommand(cmd,section.offset+0x1000)[0]
+                cmdaddress = section.offset
+                chain_tmp += self._createCommand(cmd,cmdaddress)[0]
                 can_create_command = True
-                
+
             except RopChainError as e:
                 self._printMessage('Cannot create gadget: writewhatwhere')
                 self._printMessage('Use 0x41414141 as command address. Please replace that value.')
-                address = 0x41414141
+                cmdaddress = 0x41414141
             if can_create_command:
-                
+
                 badregs = []
                 while True:
 
                     ret = self._createNumber(0x0, badRegs=badregs)
                     chain_tmp += ret[0]
                     try:
-                        chain_tmp += self._createWriteRegValueWhere(ret[1], section.offset+0x1000+length)[0]
+                        chain_tmp += self._createWriteRegValueWhere(ret[1], nulladdress)[0]
                         break
                     except BaseException as e:
                         #raise e
                         badregs.append(ret[1])
 
-                gadgets.append((self._createAddress, [section.offset+0x1000],{'reg':'ebx'},['ebx', 'bx', 'bl', 'bh']))
-                gadgets.append((self._createAddress, [section.offset+0x1000+length],{'reg':'ecx'},['ecx', 'cx', 'cl', 'ch']))
-                gadgets.append((self._createAddress, [section.offset+0x1000+length],{'reg':'edx'},['edx', 'dx', 'dl', 'dh']))
+                gadgets.append((self._createAddress, [cmdaddress],{'reg':'ebx'},['ebx', 'bx', 'bl', 'bh']))
+                gadgets.append((self._createAddress, [nulladdress],{'reg':'ecx'},['ecx', 'cx', 'cl', 'ch']))
+                gadgets.append((self._createAddress, [nulladdress],{'reg':'edx'},['edx', 'dx', 'dl', 'dh']))
                 gadgets.append((self._createNumber, [0xb],{'reg':'eax'},['eax', 'ax', 'al', 'ah']))
         if address is not None and not can_create_command:
             if type(address) is str:
-                address = int(address, 16)
+                cmdaddress = int(address, 16)
             nulladdress = options.get('nulladdress')
             if nulladdress is None:
                 self._printMessage('No address to a null bytes was given, 0x42424242 is used instead.')
@@ -673,7 +675,7 @@ class RopChainX86System(RopChainX86):
                 nulladdress = 0x42424242
             elif type(nulladdress) is str:
                 nulladdress = int(nulladdress,16)
-            gadgets.append((self._createNumber, [address],{'reg':'ebx'},['ebx', 'bx', 'bl', 'bh']))
+            gadgets.append((self._createNumber, [cmdaddress],{'reg':'ebx'},['ebx', 'bx', 'bl', 'bh']))
             gadgets.append((self._createNumber, [nulladdress],{'reg':'ecx'},['ecx', 'cx', 'cl', 'ch']))
             gadgets.append((self._createNumber, [nulladdress],{'reg':'edx'},['edx', 'dx', 'dl', 'dh']))
             gadgets.append((self._createNumber, [0xb],{'reg':'eax'},['eax', 'ax', 'al', 'ah']))
@@ -876,9 +878,9 @@ class RopChainX86VirtualProtect(RopChainX86):
 
         self._printMessage('Ropchain Generator for VirtualProtect:\n')
         self._printMessage('eax 0x90909090\necx old protection (writable addr)\nedx 0x40 (RWE)\nebx size\nesp address\nebp return address (jmp esp)\nesi pointer to VirtualProtect\nedi ret (rop nop)\n')
-        
+
         image_base = 0
-        address = options.get('address')      
+        address = options.get('address')
         given = False
         if not address:
             address, image_base = self.__getVirtualProtectEntry()
@@ -925,9 +927,9 @@ class RopChainX86VirtualProtect(RopChainX86):
 
             jmp_eax = self._searchOpcode('ff20') # jmp [eax]
             gadgets.append((self._createAddress, [jmp_eax.lines[0][0]],{'reg':'esi'},['esi','si']))
-            
+
             gadgets.append((self._createNumber, [address],{'reg':'eax'},['eax', 'ax', 'ah', 'al']))
-            
+
             pop_ebp = self._searchOpcode('5dc3')
             if pop_ebp:
                 gadgets.append((self._createAddress, [pop_ebp.lines[0][0]],{'reg':'ebp'},['ebp', 'bp']+to_extend))

--- a/ropper/ropchain/arch/ropchainx86_64.py
+++ b/ropper/ropchain/arch/ropchainx86_64.py
@@ -195,8 +195,6 @@ class RopChainX86_64(RopChain):
     def _find(self, category, reg=None, srcdst='dst', badDst=[], badSrc=None, dontModify=None, srcEqDst=False, switchRegs=False ):
         quali = 1
 
-#        print('in find')
-#        print('baddst: %s' % badDst)
         if reg and reg[0] != 'r':
             return
         while quali < RopChainSystemX86_64.MAX_QUALI:
@@ -205,51 +203,24 @@ class RopChainX86_64(RopChain):
 
                     if gadget.category[0] == category and gadget.category[1] == quali:
 
-#                        print(gadget.simpleString())
-#                        print('gadget category')
-#                        print(gadget.category)
-
-#                        print('badsrc: %s' % badSrc)
-
                         if badSrc and (gadget.category[2]['src'] in badSrc \
                                        or gadget.affected_regs.intersection(badSrc)):
-#                            print(gadget.category)
-#                            print('skipping, badsrc')
                             continue
                         if badDst and (gadget.category[2]['dst'] in badDst \
                                        or gadget.affected_regs.intersection(badDst)):
-#                            print(gadget.category)
-#                            print('skipping, baddst=%s' % str(badDst))
-#                            print(gadget.simpleInstructionString())
                             continue
                         if not gadget.lines[len(gadget.lines)-1][1].strip().endswith('ret') or 'esp' in gadget.simpleString() or 'rsp' in gadget.simpleString():
-
- #                           print(gadget.category)
- #                           print(gadget.simpleString())
- #                           print('skipping, no ending ret or contains esp/rsp')
                             continue
                         if srcEqDst and (not (gadget.category[2]['dst'] == gadget.category[2]['src'])):
- #                           print(gadget.category)
- #                           print('skipping, src != dst')
-
                             continue
                         elif not srcEqDst and 'src' in gadget.category[2] and (gadget.category[2]['dst'] == gadget.category[2]['src']):
-  #                          print(gadget.category)
-  #                          print('skipping, src = dst')
-
                             continue
                         if self._isModifiedOrDereferencedAccess(gadget, dontModify):
-   #                         print(gadget.category)
-   #                         print('skipping, is modified or defererenced')
-
                             continue
                         if reg:
                             if gadget.category[2][srcdst] == reg:
                                 if (gadget.fileName, gadget.section) not in self._usedBinaries:
                                     self._usedBinaries.append((gadget.fileName, gadget.section))
-   #                             print(gadget.category)
-   #                             print(gadget.simpleString())
-   #                             print('returning')
                                 return gadget
                             elif switchRegs:
                                 other = 'src' if srcdst == 'dst' else 'dst'
@@ -269,20 +240,12 @@ class RopChainX86_64(RopChain):
         badRegs = []
         badDst = []
         while True:
- #           print('------ createwritestringwhere ------')
- #           print('about to find')
- #           print('reg=%s' % reg)
- #           print('badDst=%s' % str(badRegs))
             popReg = self._find(Category.LOAD_REG, reg=reg, badDst=badRegs, dontModify=dontModify)
- #           print('------ createwritestringwhere ------')
             if not popReg:
                 raise RopChainError('Cannot build writewhatwhere gadget!')
             write4 = self._find(Category.WRITE_MEM, reg=popReg.category[2]['dst'],  badDst=
             badDst, srcdst='src')
             if not write4:
- #               print(popReg.category)
- #               print(popReg.simpleString())
- #               print('createwritestringwhere: appending %s' %popReg.category[2]['dst'])
                 badRegs.append(popReg.category[2]['dst'])
                 continue
             else:
@@ -326,7 +289,6 @@ class RopChainX86_64(RopChain):
             else:
                 popReg2 = self._find(Category.LOAD_REG, reg=write4.category[2]['dst'], dontModify=[what]+dontModify)
                 if not popReg2:
-                    print('writeregvaluewhere: appending %s' % write4.category[2]['dst'])
                     badDst.append(write4.category[2]['dst'])
                     continue
                 else:
@@ -418,12 +380,10 @@ class RopChainX86_64(RopChain):
                 raise RopChainError('Cannot build number with subtract gadget for reg %s!' % reg)
             popSrc = self._find(Category.LOAD_REG, reg=sub.category[2]['src'], dontModify=dontModify)
             if not popSrc:
-                print('createnumbersubtract: appending %s' % sub.category[2]['src'])
                 badRegs.append=[sub.category[2]['src']]
                 continue
             popDst = self._find(Category.LOAD_REG, reg=sub.category[2]['dst'], dontModify=[sub.category[2]['src']]+dontModify)
             if not popDst:
-                print('createnumbersubtract: appending %s' % sub.category[2]['dst'])
                 badRegs.append=[sub.category[2]['dst']]
                 continue
             else:
@@ -453,12 +413,10 @@ class RopChainX86_64(RopChain):
                 raise RopChainError('Cannot build number with addition gadget for reg %s!' % reg)
             popSrc = self._find(Category.LOAD_REG, reg=sub.category[2]['src'], dontModify=dontModify)
             if not popSrc:
-                print('createnumberaddition: appending %s' % sub.category[2]['src'])
                 badRegs.append=[sub.category[2]['src']]
                 continue
             popDst = self._find(Category.LOAD_REG, reg=sub.category[2]['dst'], dontModify=[sub.category[2]['src']]+dontModify)
             if not popDst:
-                print('createnumberaddition: appending %s' % sub.category[2]['dst'])
                 badRegs.append(sub.category[2]['dst'])
                 continue
             else:
@@ -491,7 +449,6 @@ class RopChainX86_64(RopChain):
             if not incReg:
                 if not badRegs:
                     badRegs = []
-                print('createnumberpop: appending %s' % sub.category[2]['dst'])
                 badRegs.append(popReg.category[2]['dst'])
             else:
                 break
@@ -514,7 +471,6 @@ class RopChainX86_64(RopChain):
                 if not incReg:
                     if not badRegs:
                         badRegs = []
-                    print('createnumberxor: appending %s' % sub.category[2]['src'])
                     badRegs.append(clearReg.category[2]['src'])
                 else:
                     break

--- a/ropper/ropchain/arch/ropchainx86_64.py
+++ b/ropper/ropchain/arch/ropchainx86_64.py
@@ -195,8 +195,8 @@ class RopChainX86_64(RopChain):
     def _find(self, category, reg=None, srcdst='dst', badDst=[], badSrc=None, dontModify=None, srcEqDst=False, switchRegs=False ):
         quali = 1
 
-        print('in find')
-        print('baddst: %s' % badDst)
+#        print('in find')
+#        print('baddst: %s' % badDst)
         if reg and reg[0] != 'r':
             return
         while quali < RopChainSystemX86_64.MAX_QUALI:
@@ -205,51 +205,51 @@ class RopChainX86_64(RopChain):
 
                     if gadget.category[0] == category and gadget.category[1] == quali:
 
-                        print(gadget.simpleString())
-                        print('gadget category')
-                        print(gadget.category)
+#                        print(gadget.simpleString())
+#                        print('gadget category')
+#                        print(gadget.category)
 
-                        print('badsrc: %s' % badSrc)
+#                        print('badsrc: %s' % badSrc)
 
                         if badSrc and (gadget.category[2]['src'] in badSrc \
                                        or gadget.affected_regs.intersection(badSrc)):
-                            print(gadget.category)
-                            print('skipping, badsrc')
+#                            print(gadget.category)
+#                            print('skipping, badsrc')
                             continue
                         if badDst and (gadget.category[2]['dst'] in badDst \
                                        or gadget.affected_regs.intersection(badDst)):
-                            print(gadget.category)
-                            print('skipping, baddst=%s' % str(badDst))
-                            print(gadget.simpleInstructionString())
+#                            print(gadget.category)
+#                            print('skipping, baddst=%s' % str(badDst))
+#                            print(gadget.simpleInstructionString())
                             continue
                         if not gadget.lines[len(gadget.lines)-1][1].strip().endswith('ret') or 'esp' in gadget.simpleString() or 'rsp' in gadget.simpleString():
 
-                            print(gadget.category)
-                            print(gadget.simpleString())
-                            print('skipping, no ending ret or contains esp/rsp')
+ #                           print(gadget.category)
+ #                           print(gadget.simpleString())
+ #                           print('skipping, no ending ret or contains esp/rsp')
                             continue
                         if srcEqDst and (not (gadget.category[2]['dst'] == gadget.category[2]['src'])):
-                            print(gadget.category)
-                            print('skipping, src != dst')
+ #                           print(gadget.category)
+ #                           print('skipping, src != dst')
 
                             continue
                         elif not srcEqDst and 'src' in gadget.category[2] and (gadget.category[2]['dst'] == gadget.category[2]['src']):
-                            print(gadget.category)
-                            print('skipping, src = dst')
+  #                          print(gadget.category)
+  #                          print('skipping, src = dst')
 
                             continue
                         if self._isModifiedOrDereferencedAccess(gadget, dontModify):
-                            print(gadget.category)
-                            print('skipping, is modified or defererenced')
+   #                         print(gadget.category)
+   #                         print('skipping, is modified or defererenced')
 
                             continue
                         if reg:
                             if gadget.category[2][srcdst] == reg:
                                 if (gadget.fileName, gadget.section) not in self._usedBinaries:
                                     self._usedBinaries.append((gadget.fileName, gadget.section))
-                                print(gadget.category)
-                                print(gadget.simpleString())
-                                print('returning')
+   #                             print(gadget.category)
+   #                             print(gadget.simpleString())
+   #                             print('returning')
                                 return gadget
                             elif switchRegs:
                                 other = 'src' if srcdst == 'dst' else 'dst'
@@ -269,20 +269,20 @@ class RopChainX86_64(RopChain):
         badRegs = []
         badDst = []
         while True:
-            print('------ createwritestringwhere ------')
-            print('about to find')
-            print('reg=%s' % reg)
-            print('badDst=%s' % str(badRegs))
+ #           print('------ createwritestringwhere ------')
+ #           print('about to find')
+ #           print('reg=%s' % reg)
+ #           print('badDst=%s' % str(badRegs))
             popReg = self._find(Category.LOAD_REG, reg=reg, badDst=badRegs, dontModify=dontModify)
-            print('------ createwritestringwhere ------')
+ #           print('------ createwritestringwhere ------')
             if not popReg:
                 raise RopChainError('Cannot build writewhatwhere gadget!')
             write4 = self._find(Category.WRITE_MEM, reg=popReg.category[2]['dst'],  badDst=
             badDst, srcdst='src')
             if not write4:
-                print(popReg.category)
-                print(popReg.simpleString())
-                print('createwritestringwhere: appending %s' %popReg.category[2]['dst'])
+ #               print(popReg.category)
+ #               print(popReg.simpleString())
+ #               print('createwritestringwhere: appending %s' %popReg.category[2]['dst'])
                 badRegs.append(popReg.category[2]['dst'])
                 continue
             else:

--- a/ropper/ropchain/arch/ropchainx86_64.py
+++ b/ropper/ropchain/arch/ropchainx86_64.py
@@ -611,7 +611,6 @@ class RopChainSystemX86_64(RopChainX86_64):
     def create(self, options):
         cmd = options.get('cmd')
         address = options.get('address')
-        print(addres)
         if not cmd:
             cmd = '/bin/sh'
         if len(cmd.split(' ')) > 1:

--- a/ropper/ropchain/arch/ropchainx86_64.py
+++ b/ropper/ropchain/arch/ropchainx86_64.py
@@ -194,6 +194,9 @@ class RopChainX86_64(RopChain):
 
     def _find(self, category, reg=None, srcdst='dst', badDst=[], badSrc=None, dontModify=None, srcEqDst=False, switchRegs=False ):
         quali = 1
+
+        print('in find')
+        print('baddst: %s' % badDst)
         if reg and reg[0] != 'r':
             return
         while quali < RopChainSystemX86_64.MAX_QUALI:
@@ -203,25 +206,41 @@ class RopChainX86_64(RopChain):
                     if gadget.category[0] == category and gadget.category[1] == quali:
 
                         if badSrc and gadget.category[2]['src'] in badSrc:
+                            print(gadget.category)
+                            print('skipping, badsrc')
                             continue
                         if badDst and gadget.category[2]['dst'] in badDst:
+                            print(gadget.category)
+                            print('skipping, baddst=%s' % str(badDst))
                             continue
                         if not gadget.lines[len(gadget.lines)-1][1].strip().endswith('ret') or 'esp' in gadget.simpleString() or 'rsp' in gadget.simpleString():
 
+                            print(gadget.category)
+                            print(gadget.simpleString())
+                            print('skipping, no ending ret or contains esp/rsp')
                             continue
                         if srcEqDst and (not (gadget.category[2]['dst'] == gadget.category[2]['src'])):
+                            print(gadget.category)
+                            print('skipping, src != dst')
 
                             continue
                         elif not srcEqDst and 'src' in gadget.category[2] and (gadget.category[2]['dst'] == gadget.category[2]['src']):
+                            print(gadget.category)
+                            print('skipping, src = dst')
 
                             continue
                         if self._isModifiedOrDereferencedAccess(gadget, dontModify):
+                            print(gadget.category)
+                            print('skipping, is modified or defererenced')
 
                             continue
                         if reg:
                             if gadget.category[2][srcdst] == reg:
                                 if (gadget.fileName, gadget.section) not in self._usedBinaries:
                                     self._usedBinaries.append((gadget.fileName, gadget.section))
+                                print(gadget.category)
+                                print(gadget.simpleString())
+                                print('returning')
                                 return gadget
                             elif switchRegs:
                                 other = 'src' if srcdst == 'dst' else 'dst'
@@ -241,12 +260,20 @@ class RopChainX86_64(RopChain):
         badRegs = []
         badDst = []
         while True:
+            print('------ createwritestringwhere ------')
+            print('about to find')
+            print('reg=%s' % reg)
+            print('badDst=%s' % str(badRegs))
             popReg = self._find(Category.LOAD_REG, reg=reg, badDst=badRegs, dontModify=dontModify)
+            print('------ createwritestringwhere ------')
             if not popReg:
                 raise RopChainError('Cannot build writewhatwhere gadget!')
             write4 = self._find(Category.WRITE_MEM, reg=popReg.category[2]['dst'],  badDst=
             badDst, srcdst='src')
             if not write4:
+                print(popReg.category)
+                print(popReg.simpleString())
+                print('createwritestringwhere: appending %s' %popReg.category[2]['dst'])
                 badRegs.append(popReg.category[2]['dst'])
                 continue
             else:
@@ -290,6 +317,7 @@ class RopChainX86_64(RopChain):
             else:
                 popReg2 = self._find(Category.LOAD_REG, reg=write4.category[2]['dst'], dontModify=[what]+dontModify)
                 if not popReg2:
+                    print('writeregvaluewhere: appending %s' % write4.category[2]['dst'])
                     badDst.append(write4.category[2]['dst'])
                     continue
                 else:
@@ -381,10 +409,12 @@ class RopChainX86_64(RopChain):
                 raise RopChainError('Cannot build number with subtract gadget for reg %s!' % reg)
             popSrc = self._find(Category.LOAD_REG, reg=sub.category[2]['src'], dontModify=dontModify)
             if not popSrc:
+                print('createnumbersubtract: appending %s' % sub.category[2]['src'])
                 badRegs.append=[sub.category[2]['src']]
                 continue
             popDst = self._find(Category.LOAD_REG, reg=sub.category[2]['dst'], dontModify=[sub.category[2]['src']]+dontModify)
             if not popDst:
+                print('createnumbersubtract: appending %s' % sub.category[2]['dst'])
                 badRegs.append=[sub.category[2]['dst']]
                 continue
             else:
@@ -414,10 +444,12 @@ class RopChainX86_64(RopChain):
                 raise RopChainError('Cannot build number with addition gadget for reg %s!' % reg)
             popSrc = self._find(Category.LOAD_REG, reg=sub.category[2]['src'], dontModify=dontModify)
             if not popSrc:
+                print('createnumberaddition: appending %s' % sub.category[2]['src'])
                 badRegs.append=[sub.category[2]['src']]
                 continue
             popDst = self._find(Category.LOAD_REG, reg=sub.category[2]['dst'], dontModify=[sub.category[2]['src']]+dontModify)
             if not popDst:
+                print('createnumberaddition: appending %s' % sub.category[2]['dst'])
                 badRegs.append(sub.category[2]['dst'])
                 continue
             else:
@@ -450,6 +482,7 @@ class RopChainX86_64(RopChain):
             if not incReg:
                 if not badRegs:
                     badRegs = []
+                print('createnumberpop: appending %s' % sub.category[2]['dst'])
                 badRegs.append(popReg.category[2]['dst'])
             else:
                 break
@@ -472,6 +505,7 @@ class RopChainX86_64(RopChain):
                 if not incReg:
                     if not badRegs:
                         badRegs = []
+                    print('createnumberxor: appending %s' % sub.category[2]['src'])
                     badRegs.append(clearReg.category[2]['src'])
                 else:
                     break

--- a/ropper/ropchain/arch/ropchainx86_64.py
+++ b/ropper/ropchain/arch/ropchainx86_64.py
@@ -205,13 +205,22 @@ class RopChainX86_64(RopChain):
 
                     if gadget.category[0] == category and gadget.category[1] == quali:
 
-                        if badSrc and gadget.category[2]['src'] in badSrc:
+                        print(gadget.simpleString())
+                        print('gadget category')
+                        print(gadget.category)
+
+                        print('badsrc: %s' % badSrc)
+
+                        if badSrc and (gadget.category[2]['src'] in badSrc \
+                                       or gadget.affected_regs.intersection(badSrc)):
                             print(gadget.category)
                             print('skipping, badsrc')
                             continue
-                        if badDst and gadget.category[2]['dst'] in badDst:
+                        if badDst and (gadget.category[2]['dst'] in badDst \
+                                       or gadget.affected_regs.intersection(badDst)):
                             print(gadget.category)
                             print('skipping, baddst=%s' % str(badDst))
+                            print(gadget.simpleInstructionString())
                             continue
                         if not gadget.lines[len(gadget.lines)-1][1].strip().endswith('ret') or 'esp' in gadget.simpleString() or 'rsp' in gadget.simpleString():
 


### PR DESCRIPTION
The _isModifiedOrDereferencedAccess check in the ropchain generation files is not always sufficient. This is demonstrated in the case of gadgets such as `pop rax; pop rdx; pop rbx; ret;` as discussed in #67. 

While generating a dependence chain, the first permutation checked correctly skips this gadget because `rdx` has already been added to the dontModify list. However, the second permutation checks the triple pop gadget before adding `rdx`, so it is incorrectly selected as being usable. 

This pull request adds an 'affected_regs' property to the Gadget object, which is a set() containing all of the registers that are detected as destinations across all of the gadget's instructions (not just the first instruction). An additional check in the ropchain files ensures that there is no intersection between the affected registers and any of the lists of registers that are determined to be in use.

As far as I can tell, this fixes the issue in #67, though the current result seems to be that an extra pop gadget is added after the triple pop to restore the overwritten value (but the overwritten pop gadget is still there too), which makes the payload a bit bigger than it needs to be:

```
...
rop += rebase_0(0x0000000000043126) # 0x0000000000443126: pop rdx; ret;  # Overwritten
rop += rebase_0(0x00000000002cc088)
rop += rebase_0(0x0000000000000a37) # 0x0000000000400a37: pop rdi; ret; 
rop += rebase_0(0x00000000002cb080)
rop += rebase_0(0x00000000000009e4) # 0x00000000004009e4: pop rsi; ret; 
rop += rebase_0(0x00000000002cc088)
rop += rebase_0(0x0000000000078ec6) # 0x0000000000478ec6: pop rax; pop rdx; pop rbx; ret; 
rop += p(0xdeadbeefdeadbeef)
rop += p(0xdeadbeefdeadbeef)
rop += p(0x000000000000003b)
rop += rebase_0(0x0000000000043126) # 0x0000000000443126: pop rdx; ret;  # Fixes overwrite
rop += rebase_0(0x00000000002cc088)
rop += rebase_0(0x0000000000067af5) # 0x0000000000467af5: syscall; ret; 
```