### PR TITLE
Add bad instructions for arm64

### DIFF
--- a/ropper/arch.py
+++ b/ropper/arch.py
@@ -422,7 +422,7 @@ class ArchitectureArm64(Architecture):
                                                 (b'[\x00\x20\x40\x60\x80]\x03\x3f\xd6', 4)] # blr <reg>
 
     def _initBadInstructions(self):
-        self._badInstructions = ['brk', 'hlt', 'svc', 'drps', 'hvc', 'smc', 'dcps1', 'dcps2', 'dcps3']
+        self._badInstructions = ['brk', 'hlt', 'drps', 'hvc', 'smc', 'dcps1', 'dcps2', 'dcps3']
 
 
 class ArchitecturePPC(Architecture):


### PR DESCRIPTION
I am doing some work on arm64 and found that these instructions will cause a fault / core dump in normal programs, so they're not very useful in gadgets. I got the list from the [AArch64 ISA Manual](https://www.element14.com/community/servlet/JiveServlet/previewBody/41836-102-1-229511/ARM.Reference_Manual.pdf) and then tested them with some hand assembly.