### PR TITLE
Add __main__.py and set entry_point to it

### DIFF
--- a/ropper/__main__.py
+++ b/ropper/__main__.py
@@ -18,8 +18,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-sys.path.append("filebytes")
-
 import ropper
-ropper.start(sys.argv[1:])
+import sys
+
+def main():
+    if sys.argv[0].endswith('__main__.py'):
+        sys.argv[0] = 'python -m ropper'
+    ropper.start(sys.argv[1:])
+
+if __name__ == '__main__':
+    main()

--- a/script/ropper
+++ b/script/ropper
@@ -1,3 +1,0 @@
-#!/usr/bin/env python
-# coding=utf-8
-__import__('ropper').start(__import__('sys').argv[1:])

--- a/script/ropper2
+++ b/script/ropper2
@@ -1,3 +1,0 @@
-#!/usr/bin/env python2
-# coding=utf-8
-__import__('ropper').start(__import__('sys').argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email="sashs@scoding.de",
     install_requires=install_requires,
     url="http://scoding.de/ropper/",
-    scripts=['script/ropper', 'script/ropper2'],
+    entry_points={'console_scripts': ['ropper = ropper.__main__:main']},
     classifiers=[
         'Topic :: Security',
         'Environment :: Console',


### PR DESCRIPTION
With these changes, we can use Ropper with `python -m ropper`, and setuptools will create platform-specific file to start Ropper, such as `.exe` on Windows, which is more friendly.

By the way, in `Ropper.py`, we should append `sys.path` before `import ropper`.