### PR TITLE
Load only executable sections for ELF

### DIFF
--- a/ropper/loaders/elf.py
+++ b/ropper/loaders/elf.py
@@ -73,14 +73,21 @@ class ELF(Loader):
             if self._binary.segments:
                 for phdr in self._binary.segments:
                     if phdr.header.p_flags & elf.PF.EXEC > 0:
-                        self.__execSections.append(Section(name=str(elf.PT[phdr.header.p_type]), sectionbytes=phdr.raw, virtualAddress=phdr.header.p_vaddr, offset=phdr.header.p_offset))
+                        if self._binary.sections:
+                            for shdr in self._binary.sections:
+                                if shdr.header.sh_flags & elf.SHF.EXECINSTR and shdr.header.sh_offset >= phdr.header.p_offset:
+                                    self.__execSections.append(Section(name=shdr.name, sectionbytes=shdr.raw,
+                                        virtualAddress=shdr.header.sh_addr, offset=shdr.header.sh_offset))
+                        else:
+                            self.__execSections.append(Section(name=str(elf.PT[phdr.header.p_type]), sectionbytes=phdr.raw,
+                                virtualAddress=phdr.header.p_vaddr, offset=phdr.header.p_offset))
             elif self._binary.sections:
                 for shdr in self._binary.sections:
                     print(shdr.header.sh_flags)
                     if shdr.header.sh_flags & elf.SHF.EXECINSTR:
                         self.__execSections.append(Section(name=shdr.name, sectionbytes=shdr.raw, virtualAddress=shdr.header.sh_addr, offset=shdr.header.sh_offset))
 
-                
+
         return self.__execSections
 
     @property


### PR DESCRIPTION
In some cases executable segments can contain
both executable and non-executable sections,
so even if the address is located in the executable
segment, it is not still the code. So we can safely
skip those.