### PR TITLE
Add support for Mach-O universal binaries.

### DIFF
--- a/ropper/loaders/mach_o.py
+++ b/ropper/loaders/mach_o.py
@@ -98,7 +98,15 @@ class MachO(Loader):
         return {}
 
     def _loadFile(self, fileName, bytes=None):
-        return macho.MachO(fileName, bytes)
+        mf = macho.MachO(fileName, bytes)
+        if mf.isFat:
+            if not self._arch:
+                return mf.fatArches[0]
+            for arch in mf.fatArches:
+                if ARCH[arch.machHeader.header.cputype] == self._arch:
+                    return arch
+        return mf
+
 
     @classmethod
     def isSupportedFile(cls, fileName, bytes=None):


### PR DESCRIPTION
If the detected file is a Mach-O fat file, the arch specified to Ropper
will be selected from the slice of Mach-O images within the fat file. If
no arch is specified, the first slice is used.

This also updates the filebytes submodule to include sashs/filebytes#20,
but that might not be how you manage the submodules for Ropper. Feel
free to update as necessary. The change to ropper/loaders/mach_o.py is
small.

Closes sashs/filebytes#9.