### PR TITLE
Fix _createNumberNeg printing values out of order on x86

### DIFF
--- a/ropper/ropchain/arch/ropchainx86.py
+++ b/ropper/ropchain/arch/ropchainx86.py
@@ -543,11 +543,9 @@ class RopChainX86(RopChain):
         if not pop:
             raise RopChainError('Cannot build number gadget with neg!')
 
-        toReturn = self._printRopInstruction(pop)
-
-
         value = self._printPaddingInstruction(toHex((~number)+1)) # two's complement
-        toReturn += self._printRopInstruction(neg, value=value)
+        toReturn = self._printRopInstruction(pop, value=value)
+        toReturn += self._printRopInstruction(neg)
         return (toReturn, reg,)
 
     def _createNumber(self, number, reg=None, badRegs=None, dontModify=None, xchg=True):


### PR DESCRIPTION
x86 ropchains print out of order if _createNumberNeg is used. 

Before patch:
rop += rebase_0(0x00024a67) # 0xf7d92a67: pop eax; ret; 
rop += rebase_0(0x00019aee) # 0xf7d87aee: neg eax; ret; 
rop += p(0xffffff83)

After:
rop += rebase_0(0x00024a67) # 0xf7d92a67: pop eax; ret; 
rop += p(0xffffff83)
rop += rebase_0(0x00019aee) # 0xf7d87aee: neg eax; ret;