### PR TITLE
Conver result of unhexlify to str

### DIFF
--- a/ropper/console.py
+++ b/ropper/console.py
@@ -359,7 +359,7 @@ class Console(cmd.Cmd):
                         raise RopperError('Wrong option format. An option has to be set in the following format: option=value')
                     key, value = option.split('=')
                     options[key] = value
-                    if any(badbyte in value for badbyte in unhexlify(badbytes)):
+                    if any(badbyte in value for badbyte in str(unhexlify(badbytes))):
                         value_with_badbytes = value
             try:
 


### PR DESCRIPTION
Greetings.
It is possible it was just a problem for me, but any time I tried to run a search with bad bytes specified, I ran into the following issue:

```
[ERROR] Please report this error on https://github.com/sashs/ropper
[ERROR] Traceback (most recent call last):
  File "/home/kali/Desktop/Ropper/ropper/console.py", line 62, in cmd
    func(self, text)
  File "/home/kali/Desktop/Ropper/ropper/console.py", line 508, in __handleOptions
    self.__generateChain(options.chain)
  File "/home/kali/Desktop/Ropper/ropper/console.py", line 386, in __generateChain
    raise e
  File "/home/kali/Desktop/Ropper/ropper/console.py", line 362, in __generateChain
    if any(badbyte in value for badbyte in unhexlify(badbytes)):
  File "/home/kali/Desktop/Ropper/ropper/console.py", line 362, in <genexpr>
    if any(badbyte in value for badbyte in unhexlify(badbytes)):
TypeError: 'in <string>' requires string as left operand, not int
```

Seems this fixes it.