### PR TITLE
Detect invalid gadgets

### DIFF
--- a/ropper/arch.py
+++ b/ropper/arch.py
@@ -30,7 +30,7 @@ from ropper.common.abstract import *
 from ropper.common.enum import Enum
 from ropper.common.error import NotSupportedError
 from ropper.search import Searcher, Searcherx86, SearcherARM, SearcherMIPS
-from re import compile
+import re
 from capstone import *
 from . import gadget
 try:
@@ -72,6 +72,7 @@ class Architecture(AbstractSingleton):
         self._align = align
 
         self._endings = {}
+        self._endings_re = None
         self._badInstructions = []
         self._categories = {}
         self._maxInvalid = 1
@@ -137,7 +138,13 @@ class Architecture(AbstractSingleton):
     @property
     def endings(self):
         return self._endings
-
+    
+    @property
+    def endings_re(self):
+        if not self._endings_re:
+            self._endings_re = {key: [(re.compile(x), y)  for x, y in value] for key, value in self.endings.items()}
+        return self._endings_re
+            
     @property
     def badInstructions(self):
         return self._badInstructions
@@ -202,8 +209,8 @@ class ArchitectureX86(Architecture):
 
     def _initGadgets(self):
         super(ArchitectureX86, self)._initGadgets()
-        self._endings[gadget.GadgetType.ROP] = [(b'\xc3', 1),                           # ret
-                                                (b'\xc2[\x00-\xff]{2}', 3)]             # ret xxx
+        self._endings[gadget.GadgetType.ROP] = [(b'[\xc3|\xcb]', 1),                           # ret
+                                                (b'[\xc2|\xca][\x00-\xff]{2}', 3)]             # ret xxx
 
         self._endings[gadget.GadgetType.SYS] = [(b'\xcd\x80', 2),                           # int 0x80
                                                 (b'\x0f\x05',2),                            # syscall
@@ -383,9 +390,9 @@ class ArchitectureArm(Architecture):
 
     def _initGadgets(self):
         super(ArchitectureArm, self)._initGadgets()
-        self._endings[gadget.GadgetType.ROP] = [(b'[\x01-\xff]\x80\xbd\xe8', 4)] # pop {[reg]*,pc}
-        self._endings[gadget.GadgetType.JOP] = [(b'[\x10-\x1e]\xff\x2f\xe1', 4), # bx <reg>
-                                                (b'[\x30-\x3e]\xff\x2f\xe1', 4), # blx <reg>
+        self._endings[gadget.GadgetType.ROP] = [(b'[\x00-\xff][\x80-\xff][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\xe8\xe9]', 4)]
+        self._endings[gadget.GadgetType.JOP] = [(b'[\x10-\x19\x1e]{1}\xff\x2f\xe1', 4), # bx <reg>
+                                                (b'[\x30-\x39\x3e]{1}\xff\x2f\xe1', 4), # blx <reg>
                                                 (b'[\x00-\x0f]\xf0\xa0\xe1', 4), # mov pc, <reg>
                                                 (b'\x01\x80\xbd\xe8', 4)] # ldm sp! ,{pc}
 
@@ -401,9 +408,9 @@ class ArchitectureArmBE(ArchitectureArm):
 
     def _initEndianess(self, endianess):
         super(ArchitectureArmBE, self)._initEndianess(endianess)
-        self._endings[gadget.GadgetType.ROP] = [(b'\xe8\xbd\x80[\x01-\xff]', 4)] # pop {[reg]*,pc}
-        self._endings[gadget.GadgetType.JOP] = [(b'\xe1\x2f\xff[\x10-\x1e]', 4), # bx <reg>
-                                                (b'\xe1\x2f\xff[\x30-\x3e]', 4), # blx <reg>
+        self._endings[gadget.GadgetType.ROP] = [(b'[\xe8\xe9][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\x80-\xff][\x00-\xff]', 4)] # pop {[reg]*,pc}
+        self._endings[gadget.GadgetType.JOP] = [(b'\xe1\x2f\xff[\x10-\x19\x1e]{1}', 4), # bx <reg>
+                                                (b'\xe1\x2f\xff[\x30-\x39\x3e]{1}', 4), # blx <reg>
                                                 (b'\xe1\xa0\xf0[\x00-\x0f]', 4), # mov pc, <reg>
                                                 (b'\xe8\xdb\x80\x01', 4)] # ldm sp! ,{pc}
 
@@ -424,7 +431,7 @@ class ArchitectureArmThumb(Architecture):
     def _initGadgets(self):
         super(ArchitectureArmThumb, self)._initGadgets()
         self._endings[gadget.GadgetType.ROP] = [(b'[\x00-\xff]\xbd', 2)] # pop {[regs]*,pc}
-        self._endings[gadget.GadgetType.JOP] = [(b'[\x00-\x7f]\x47', 2), # bx <reg>
+        self._endings[gadget.GadgetType.JOP] = [(b'[\x00\x08\x10\x18\x20\x28\x30\x38\x40\x48\x70]{1}\x47', 2), # bx <reg>
                                                 (b'[\x80\x88\x90\x98\xa0\xa8\xb0\xb8\xc0\xc8\xd0\xd8\xe0\xe8\xf0\xf8]\x47', 2) # blx <reg>
                                                 ]
 

--- a/ropper/arch.py
+++ b/ropper/arch.py
@@ -414,6 +414,7 @@ class ArchitectureArmBE(ArchitectureArm):
                                                 (b'\xe1\xa0\xf0[\x00-\x0f]', 4), # mov pc, <reg>
                                                 (b'\xe8\xdb\x80\x01', 4)] # ldm sp! ,{pc}
 
+
 class ArchitectureArmThumb(Architecture):
 
     def __init__(self):
@@ -431,11 +432,9 @@ class ArchitectureArmThumb(Architecture):
     def _initGadgets(self):
         super(ArchitectureArmThumb, self)._initGadgets()
         self._endings[gadget.GadgetType.ROP] = [(b'[\x00-\xff]\xbd', 2)] # pop {[regs]*,pc}
-        self._endings[gadget.GadgetType.JOP] = [(b'[\x00\x08\x10\x18\x20\x28\x30\x38\x40\x48\x70]{1}\x47', 2), # bx <reg>
+        self._endings[gadget.GadgetType.JOP] = [(b'[\x00-\x7f]\x47', 2), # bx <reg>
                                                 (b'[\x80\x88\x90\x98\xa0\xa8\xb0\xb8\xc0\xc8\xd0\xd8\xe0\xe8\xf0\xf8]\x47', 2) # blx <reg>
                                                 ]
-
-
 
 
 class ArchitectureArm64(Architecture):

--- a/ropper/rop.py
+++ b/ropper/rop.py
@@ -455,7 +455,7 @@ class Ropper(object):
         gadget = Gadget(binary, section, arch)
         hasret = False
         disassembler = self.__getCs(arch)
-        instrs = list(disassembler.disasm(code_str, codeStartAddress+gadget.imageBase))
+        instrs = list(disassembler.disasm(code_str, codeStartAddress))
         for i, inst in enumerate(instrs):
             
             if re.match(ending[0], inst.bytes):

--- a/ropper/rop.py
+++ b/ropper/rop.py
@@ -454,19 +454,28 @@ class Ropper(object):
     def __createGadget(self, arch, code_str, codeStartAddress, ending, binary=None, section=None):
         gadget = Gadget(binary, section, arch)
         hasret = False
-        if codeStartAddress == 0x0000000001b34d74:
-            print("found")
         disassembler = self.__getCs(arch)
-
-        for i in disassembler.disasm(code_str, codeStartAddress):
-            if re.match(ending[0], i.bytes):
+        instrs = list(disassembler.disasm(code_str, codeStartAddress+gadget.imageBase))
+        for i, inst in enumerate(instrs):
+            
+            if re.match(ending[0], inst.bytes):
                 hasret = True
 
-            if hasret or i.mnemonic not in arch.badInstructions:
-                gadget.append(
-                    i.address, i.mnemonic,i.op_str, bytes=i.bytes)
+            reset_gadget = False
+            if i != len(instrs)-1:
+                for ending2 in arch.endings_re[GadgetType.ROP]:
+                    if ending2[0].match(inst.bytes):
+                        # anything before this (including this instr) isn't part of this gadget
+                        reset_gadget = True
+                        break
+            if reset_gadget:
+                gadget = Gadget(binary, section, arch)
+                continue
 
-            if (hasret and not arch.hasBranchDelaySlot) or i.mnemonic in arch.badInstructions:
+            if hasret or inst.mnemonic not in arch.badInstructions:
+                gadget.append(inst.address, inst.mnemonic,inst.op_str, bytes=inst.bytes)
+
+            if (hasret and not arch.hasBranchDelaySlot) or inst.mnemonic in arch.badInstructions:
                 break
 
 


### PR DESCRIPTION
Some gadgets that Ropper would generate would have an ARM 'pop {..., pc}' instruction or an x86 'ret' instruction in the middle because the instruction happen to land in the previous 'n' instructions of the gadget.

This pull requests detects these and removes all previous instructions from the currently built gadget because it is impossible to execute the full gadget without invoking it as two separate gadgets. 

e.g.
```
0x00015568 (0x00015569): pop {r4, r5, pc}; nop; teq.w r0, #0; itt eq; moveq r1, #0; bxeq lr;
```
becomes
```
0x0001556a (0x0001556b): nop; teq.w r0, #0; itt eq; moveq r1, #0; bxeq lr;
```