### PR TITLE
Control cache location with environment variables

### DIFF
--- a/ropper/service.py
+++ b/ropper/service.py
@@ -270,8 +270,8 @@ class Options(object):
 
 class RopperService(object):
 
-    ROPPER_FOLDER = os.path.expanduser('~') + os.path.sep + ".ropper/"
-    CACHE_FOLDER = os.path.expanduser('~') + os.path.sep + ".ropper/cache/"
+    ROPPER_FOLDER = os.environ.get("ROPPER_FOLDER") or os.path.join(os.path.expanduser('~'), ".ropper/")
+    CACHE_FOLDER = os.environ.get("ROPPER_CACHE") or os.path.join(ROPPER_FOLDER, "cache/")
     CACHE_FILE_COUNT = 16
 
     def __init__(self, options={}, callbacks=None):


### PR DESCRIPTION
Right now, the cache's location is hardcoded to the user's homedir. This lets them set the `ROPPER_FOLDER` or `ROPPER_CACHE` environment variables to change this, while maintaining the old defaults.