### PR TITLE
BUGFIX: gadgets missed because of a bad declaration of the pop pc gadget.

### DIFF
--- a/ropper/arch.py
+++ b/ropper/arch.py
@@ -383,7 +383,7 @@ class ArchitectureArm(Architecture):
 
     def _initGadgets(self):
         super(ArchitectureArm, self)._initGadgets()
-        self._endings[gadget.GadgetType.ROP] = [(b'[\x01-\xff]\x80\xbd\xe8', 4)] # pop {[reg]*,pc}
+        self._endings[gadget.GadgetType.ROP] = [(b"[\x00-\xff][\x80-\xff][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\xe8\xe9]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
         self._endings[gadget.GadgetType.JOP] = [(b'[\x10-\x1e]\xff\x2f\xe1', 4), # bx <reg>
                                                 (b'[\x30-\x3e]\xff\x2f\xe1', 4), # blx <reg>
                                                 (b'[\x00-\x0f]\xf0\xa0\xe1', 4), # mov pc, <reg>
@@ -401,7 +401,7 @@ class ArchitectureArmBE(ArchitectureArm):
 
     def _initEndianess(self, endianess):
         super(ArchitectureArmBE, self)._initEndianess(endianess)
-        self._endings[gadget.GadgetType.ROP] = [(b'\xe8\xbd\x80[\x01-\xff]', 4)] # pop {[reg]*,pc}
+        self._endings[gadget.GadgetType.ROP] = [(b"[\xe8\xe9][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\x80-\xff][\x00-\xff]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
         self._endings[gadget.GadgetType.JOP] = [(b'\xe1\x2f\xff[\x10-\x1e]', 4), # bx <reg>
                                                 (b'\xe1\x2f\xff[\x30-\x3e]', 4), # blx <reg>
                                                 (b'\xe1\xa0\xf0[\x00-\x0f]', 4), # mov pc, <reg>

--- a/ropper/arch.py
+++ b/ropper/arch.py
@@ -383,7 +383,7 @@ class ArchitectureArm(Architecture):
 
     def _initGadgets(self):
         super(ArchitectureArm, self)._initGadgets()
-        self._endings[gadget.GadgetType.ROP] = [(b"[\x00-\xff][\x80-\xff][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\xe8\xe9]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
+        self._endings[gadget.GadgetType.ROP] = [(b"[\x00-\xff][\x80-\xff][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\xe4\xe8\xe9]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
         self._endings[gadget.GadgetType.JOP] = [(b'[\x10-\x1e]\xff\x2f\xe1', 4), # bx <reg>
                                                 (b'[\x30-\x3e]\xff\x2f\xe1', 4), # blx <reg>
                                                 (b'[\x00-\x0f]\xf0\xa0\xe1', 4), # mov pc, <reg>
@@ -401,7 +401,7 @@ class ArchitectureArmBE(ArchitectureArm):
 
     def _initEndianess(self, endianess):
         super(ArchitectureArmBE, self)._initEndianess(endianess)
-        self._endings[gadget.GadgetType.ROP] = [(b"[\xe8\xe9][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\x80-\xff][\x00-\xff]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
+        self._endings[gadget.GadgetType.ROP] = [(b"[\xe4\xe8\xe9][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\x80-\xff][\x00-\xff]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
         self._endings[gadget.GadgetType.JOP] = [(b'\xe1\x2f\xff[\x10-\x1e]', 4), # bx <reg>
                                                 (b'\xe1\x2f\xff[\x30-\x3e]', 4), # blx <reg>
                                                 (b'\xe1\xa0\xf0[\x00-\x0f]', 4), # mov pc, <reg>

--- a/ropper/arch.py
+++ b/ropper/arch.py
@@ -383,7 +383,9 @@ class ArchitectureArm(Architecture):
 
     def _initGadgets(self):
         super(ArchitectureArm, self)._initGadgets()
-        self._endings[gadget.GadgetType.ROP] = [(b"[\x00-\xff][\x80-\xff][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\xe4\xe8\xe9]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
+        self._endings[gadget.GadgetType.ROP] = [(b"[\x00-\xff][\x80-\xff][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\xe8\xe9]", 4), # pop {[reg]*,pc}, ldm [reg], {*,pc}
+            (b"\x04\xf0\x9d\xe4", 4) # pop {pc}
+        ] 
         self._endings[gadget.GadgetType.JOP] = [(b'[\x10-\x1e]\xff\x2f\xe1', 4), # bx <reg>
                                                 (b'[\x30-\x3e]\xff\x2f\xe1', 4), # blx <reg>
                                                 (b'[\x00-\x0f]\xf0\xa0\xe1', 4), # mov pc, <reg>
@@ -401,7 +403,9 @@ class ArchitectureArmBE(ArchitectureArm):
 
     def _initEndianess(self, endianess):
         super(ArchitectureArmBE, self)._initEndianess(endianess)
-        self._endings[gadget.GadgetType.ROP] = [(b"[\xe4\xe8\xe9][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\x80-\xff][\x00-\xff]", 4)] # pop {[reg]*,pc}, ldm [reg], {*,pc}
+        self._endings[gadget.GadgetType.ROP] = [(b"[\xe8\xe9][\x10-\x1e\x30-\x3e\x50-\x5e\x70-\x7e\x90-\x9e\xb0-\xbe\xd0-\xde\xf0-\xfe][\x80-\xff][\x00-\xff]", 4), # pop {[reg]*,pc}, ldm [reg], {*,pc}
+            (b"\xe4\x9d\xf0\x04", 4) # pop {pc}
+        ]
         self._endings[gadget.GadgetType.JOP] = [(b'\xe1\x2f\xff[\x10-\x1e]', 4), # bx <reg>
                                                 (b'\xe1\x2f\xff[\x30-\x3e]', 4), # blx <reg>
                                                 (b'\xe1\xa0\xf0[\x00-\x0f]', 4), # mov pc, <reg>


### PR DESCRIPTION
The pattern of a `pop pc` gadget in [arch.py](https://github.com/sashs/Ropper/blob/master/ropper/arch.py#L386) does not cover all the cases, making ropper to miss a lot of gadgets in ARM and ARMBE.

Fix this pattern to identify all possible instructions that ends up in a usable gadget is not an easy task. After a few attempts to fix this pattern myself, I finally decided to use the same pattern that is used in [ROPGadget](https://github.com/JonathanSalwan/ROPgadget/blob/master/ropgadget/gadgets.py#L286).

I'm not sure that it's perfect, but it's for sure a better version than the current pattern in ropper.

ropper is now able to find gadgets like `pop {r4, r5, r6, r7, r8, pc};` in ARM and ARMBE.