### PR TITLE
fixed typos and grammatical errors in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Usage
       -r, --raw             Loads the file as raw file
       -a <arch>, --arch <arch>
                             The architecture of the loaded file
-      --section <section>   The data of the this section should be printed
+      --section <section>   The data of this section should be printed
       --string [<string>]   Looks for the string <string> in all data sections
       --hex                 Prints the selected sections in a hex format
       --asm <asm> [H|S|R] [<asm> [H|S|R] ...]
@@ -149,7 +149,7 @@ Usage
       --symbols             Shows symbols [ELF]
       --set <option>        Sets options. Available options: aslr nx
       --unset <option>      Unsets options. Available options: aslr nx
-      -I <imagebase>        Uses this imagebase for gadgets
+      -I <imagebase>        Use this imagebase for gadgets
       -p, --ppr             Searches for 'pop reg; pop reg; ret' instructions
                             [only x86/x86_64]
       -j <reg>, --jmp <reg>
@@ -176,7 +176,7 @@ Usage
       --chain <generator>   Generates a ropchain [generator parameter=value[
                             parameter=value]]
       -b <badbytes>, --badbytes <badbytes>
-                            Set bytes which should not contains in gadgets
+                            Set bytes which should not be contained in gadgets
       --nocolor             Disables colored output
       --clear-cache         Clears the cache
 

--- a/README.md
+++ b/README.md
@@ -83,17 +83,20 @@ Constraint Example
 Usage
 -----
 
-    usage: Ropper.py [-h] [-v] [--console] [-f <file>] [-r] [-a <arch>]
-                     [--section <section>] [--string [<string>]] [--hex]
-                     [--asm <asm> [H|S|R] [<asm> [H|S|R] ...]] [--disasm <opcode>]
-                     [--disassemble-address <address:length>] [-i] [-e]
-                     [--imagebase] [-c] [-s] [-S] [--imports] [--symbols]
-                     [--set <option>] [--unset <option>] [-I <imagebase>] [-p]
-                     [-j <reg>] [--stack-pivot] [--inst-count <n bytes>]
-                     [--search <regex>] [--quality <quality>] [--opcode <opcode>]
-                     [--instructions <instructions>] [--type <type>] [--detailed]
-                     [--all] [--cfg-only] [--chain <generator>] [-b <badbytes>]
-                     [--nocolor] [--clear-cache]
+    usage: Ropper.py [-h] [--help-examples] [-v] [--console]
+                 [-f <file> [<file> ...]] [-r] [-a <arch>]
+                 [--section <section>] [--string [<string>]] [--hex]
+                 [--asm [<asm> [H|S|R] ...]] [--disasm <opcode>]
+                 [--disassemble-address <address:length>] [-i] [-e]
+                 [--imagebase] [-c] [-s] [-S] [--imports] [--symbols]
+                 [--set <option>] [--unset <option>] [-I <imagebase>] [-p]
+                 [-j <reg>] [--stack-pivot] [--inst-count <n bytes>]
+                 [--search <regex>] [--quality <quality>] [--opcode <opcode>]
+                 [--instructions <instructions>] [--type <type>] [--detailed]
+                 [--all] [--cfg-only] [--chain <generator>] [-b <badbytes>]
+                 [--nocolor] [--clear-cache] [--no-load] [--analyse <quality>]
+                 [--semantic constraint]
+                 [--count-of-findings <count of gadgets>] [--single]
 
     You can use ropper to display information about binary files in different file formats
         and you can search for gadgets to build rop chains for different architectures
@@ -118,11 +121,12 @@ Usage
       mprotect  (mprotect=<address>:<size>) [Linux x86, x86_64]
       virtualprotect (virtualprotect=<address iat vp>:<size>) [Windows x86]
 
-    optional arguments:
+    options:
       -h, --help            show this help message and exit
+      --help-examples       Print examples
       -v, --version         Print version
       --console             Starts interactive commandline
-      -f <file>, --file <file>
+      -f <file> [<file> ...], --file <file> [<file> ...]
                             The file to load
       -r, --raw             Loads the file as raw file
       -a <arch>, --arch <arch>
@@ -130,7 +134,7 @@ Usage
       --section <section>   The data of this section should be printed
       --string [<string>]   Looks for the string <string> in all data sections
       --hex                 Prints the selected sections in a hex format
-      --asm <asm> [H|S|R] [<asm> [H|S|R] ...]
+      --asm [<asm> [H|S|R] ...]
                             A string to assemble and a format of the output
                             (H=HEX, S=STRING, R=RAW, default: H)
       --disasm <opcode>     Opcode to disassemble (e.g. ffe4, 89c8c3, ...)
@@ -179,6 +183,15 @@ Usage
                             Set bytes which should not be contained in gadgets
       --nocolor             Disables colored output
       --clear-cache         Clears the cache
+      --no-load             Don't load the gadgets automatically when starting the
+                            console (--console)
+      --analyse <quality>   just used for the implementation of semantic search
+      --semantic constraint
+                            semantic search for gadgets
+      --count-of-findings <count of gadgets>
+                            Max count of gadgets which will be printed with
+                            semantic search (0 = undefined, default: 5)
+      --single              No multiple processes are used for gadget scanning
 
     example uses:
       [Generic]

--- a/ropper/options.py
+++ b/ropper/options.py
@@ -88,7 +88,7 @@ available rop chain generators:
         parser.add_argument(
             '-a', '--arch', metavar="<arch>", help='The architecture of the loaded file')
         parser.add_argument(
-            '--section', help='The data of the this section should be printed', metavar='<section>')
+            '--section', help='The data of this section should be printed', metavar='<section>')
         parser.add_argument(
             '--string', help='Looks for the string <string> in all data sections', metavar='<string>',nargs='?', const='[ -~]{2}[ -~]*')
         parser.add_argument(
@@ -119,7 +119,7 @@ available rop chain generators:
             '--set', help='Sets options. Available options: aslr nx', metavar='<option>')
         parser.add_argument(
             '--unset', help='Unsets options. Available options: aslr nx', metavar='<option>')
-        parser.add_argument('-I', metavar='<imagebase>', help='Uses this imagebase for gadgets')
+        parser.add_argument('-I', metavar='<imagebase>', help='Use this imagebase for gadgets')
         parser.add_argument(
             '-p', '--ppr', help='Searches for \'pop reg; pop reg; ret\' instructions [only x86/x86_64]', action='store_true')
         parser.add_argument(
@@ -147,13 +147,13 @@ available rop chain generators:
         parser.add_argument(
             '--chain', help='Generates a ropchain [generator parameter=value[ parameter=value]]', metavar='<generator>')
         parser.add_argument(
-            '-b', '--badbytes', help='Set bytes which should not contains in gadgets', metavar='<badbytes>', default='')
+            '-b', '--badbytes', help='Set bytes which should not be contained in gadgets', metavar='<badbytes>', default='')
         parser.add_argument(
             '--nocolor', help='Disables colored output', action='store_true')
         parser.add_argument(
             '--clear-cache', help='Clears the cache', action='store_true')
         parser.add_argument(
-            '--no-load', help='Don\'t load the gadgets automatically when start the console (--console)', action='store_true', default=False)
+            '--no-load', help='Don\'t load the gadgets automatically when starting the console (--console)', action='store_true', default=False)
         parser.add_argument(
             '--analyse', help='just used for the implementation of semantic search', metavar='<quality>')
         parser.add_argument(


### PR DESCRIPTION
These already bugged me for a while ;)
I also adapted the `README` file accordingly.
While doing this I noticed that a few options are missing in the `README`, so I added them.