### PR TITLE
Add pop.w regex pattern for ArmThumb architecture

### DIFF
--- a/ropper/arch.py
+++ b/ropper/arch.py
@@ -427,7 +427,9 @@ class ArchitectureArmThumb(Architecture):
 
     def _initGadgets(self):
         super(ArchitectureArmThumb, self)._initGadgets()
-        self._endings[gadget.GadgetType.ROP] = [(b'[\x00-\xff]\xbd', 2)] # pop {[regs]*,pc}
+        self._endings[gadget.GadgetType.ROP] = [(b'[\x00-\xff]\xbd', 2), # pop {[regs]*,pc}
+                                                (b'\xbd\xe8[\x00-\xff][\x80-\xff]', 4) # pop.w {[regs]*,pc}
+                                                ]
         self._endings[gadget.GadgetType.JOP] = [(b'[\x00-\x7f]\x47', 2), # bx <reg>
                                                 (b'[\x80\x88\x90\x98\xa0\xa8\xb0\xb8\xc0\xc8\xd0\xd8\xe0\xe8\xf0\xf8]\x47', 2) # blx <reg>
                                                 ]


### PR DESCRIPTION
This PR adds some missing regex for the ArmThumb architecture.
Prior to this PR ropper only searched for 16bits `pop`  instructions and missed the 32bits  `pop.w` instructions.