### PR TITLE
Updates Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM python
 
-LABEL MAINTAINER "oddrabbit"
+LABEL MAINTAINER="oddrabbit"
 
 WORKDIR /app
 
@@ -11,10 +11,7 @@ RUN apt-get update \
         && apt-get install git -y \
         && git clone https://github.com/sashs/Ropper.git \
         && cd Ropper \
-        && pip3 install capstone==4.0.1 \
-        && pip3 install filebytes==0.10.0 \
-        && pip3 install keystone-engine \
-        && python ./setup.py install
+        && pip3 install .
 
 ENTRYPOINT ["python", "/app/Ropper/Ropper.py"]
 


### PR DESCRIPTION
setup.py was removed in commit 525bcf7f047eef9f2c32b93bfb132e7f2488d96c which broke the Dockerfile. Just using pip3 to install ropper seems to do the trick but let me know what you think.